### PR TITLE
load deck\mana intensity

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -111,7 +111,7 @@ def main_menu():
     return choice
     
 def valid_choice(choice):
-    if choice == "1":
+    if choice == "1" or choice == "2":
         return choice
     else:
         print("Please select a valid option.")
@@ -327,7 +327,29 @@ def create_csv():
     deck_name = input('Enter the name of the deck')
     print('exporting to csv file...')
     deck.to_csv('{}.csv'.format(deck_name))
-       
+    
+def count_colors():
+    i = 0
+    white, blue, black, green, red = 0 , 0 , 0 , 0 , 0
+    while i<99:
+        deck['Mana_Cost'] = deck['Mana_Cost'].astype(str)
+        if deck.at[i, 'Mana_Cost'] == 'NaN':
+            i += 1
+        else:
+            white += deck.at[i, 'Mana_Cost'].count('W')
+            blue += deck.at[i, 'Mana_Cost'].count('U')
+            black += deck.at[i, 'Mana_Cost'].count('B')
+            green += deck.at[i, 'Mana_Cost'].count('G')
+            red += deck.at[i, 'Mana_Cost'].count('R') 
+            i+= 1
+    print(white, red, green, blue, black)
+            
+def load_deck():
+    deck_name = input('please enter the name of the deck you want to load')
+    deck = pd.read_csv('{}.csv'.format(deck_name))
+    return deck   
+
+
  
 choice = main_menu()
 
@@ -355,7 +377,11 @@ if choice == "1":
     
     
     
+elif choice == '2':
+    deck = load_deck()
+    print(deck)
+    count_colors()
+    
 else:
     print("working on it")
-    
-    
+       

--- a/jodah and friends.csv
+++ b/jodah and friends.csv
@@ -1,0 +1,230 @@
+,Name,Description,Type,Sub-type,Power,Toughness,Commander,Mana_Cost,CMC,Color_Identity
+0,"Jodah, the Unifier","Legendary creatures you control get +X/+X, where X is the number of legendary creatures you control.
+Whenever you cast a legendary spell from your hand, exile cards from the top of your library until you exile a legendary nonland card with lesser mana value. You may cast that card without paying its mana cost. Put the rest on the bottom of your library in a random order.",Legendary Creature - Human Wizard,Creature,5,5,True,{W}{U}{B}{R}{G},5.0,"B,G,R,U,W"
+1,Nimbus Maze,"{T}: Add {C}.
+{T}: Add {W}. Activate only if you control an Island.
+{T}: Add {U}. Activate only if you control a Plains.",Land,Land,,,False,,0.0,"U,W"
+2,Adarkar Wastes,"{T}: Add {C}.
+{T}: Add {W} or {U}. Adarkar Wastes deals 1 damage to you.",Land,Land,,,False,,0.0,"U,W"
+3,Hallowed Fountain,"({T}: Add {W} or {U}.)
+As Hallowed Fountain enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",Land - Plains Island,Land,,,False,,0.0,"U,W"
+4,Spara's Headquarters,"({T}: Add {G}, {W}, or {U}.)
+Spara's Headquarters enters the battlefield tapped.
+Cycling {3} ({3}, Discard this card: Draw a card.)",Land - Forest Plains Island,Land,,,False,,0.0,"G,U,W"
+5,Clearwater Pathway // Murkwater Pathway,{T}: Add {U}.,Land,Land,,,False,,0.0,"B,U"
+6,Exotic Orchard,{T}: Add one mana of any color that a land an opponent controls could produce.,Land,Land,,,False,,0.0,C
+7,Vault of Champions,"Vault of Champions enters the battlefield tapped unless you have two or more opponents.
+{T}: Add {W} or {B}.",Land,Land,,,False,,0.0,"B,W"
+8,Razorverge Thicket,"Razorverge Thicket enters the battlefield tapped unless you control two or fewer other lands.
+{T}: Add {G} or {W}.",Land,Land,,,False,,0.0,"G,W"
+9,Needleverge Pathway // Pillarverge Pathway,{T}: Add {R}.,Land,Land,,,False,,0.0,"R,W"
+10,Training Center,"Training Center enters the battlefield tapped unless you have two or more opponents.
+{T}: Add {U} or {R}.",Land,Land,,,False,,0.0,"R,U"
+11,Fetid Heath,"{T}: Add {C}.
+{W/B}, {T}: Add {W}{W}, {W}{B}, or {B}{B}.",Land,Land,,,False,,0.0,"B,W"
+12,Canopy Vista,"({T}: Add {G} or {W}.)
+Canopy Vista enters the battlefield tapped unless you control two or more basic lands.",Land - Forest Plains,Land,,,False,,0.0,"G,W"
+13,Morphic Pool,"Morphic Pool enters the battlefield tapped unless you have two or more opponents.
+{T}: Add {U} or {B}.",Land,Land,,,False,,0.0,"B,U"
+14,Seachrome Coast,"Seachrome Coast enters the battlefield tapped unless you control two or fewer other lands.
+{T}: Add {W} or {U}.",Land,Land,,,False,,0.0,"U,W"
+15,"Yavimaya, Cradle of Growth",Each land is a Forest in addition to its other land types.,Legendary Land,Land,,,False,,0.0,C
+16,The World Tree,"The World Tree enters the battlefield tapped.
+{T}: Add {G}.
+As long as you control six or more lands, lands you control have ""{T}: Add one mana of any color.""
+{W}{W}{U}{U}{B}{B}{R}{R}{G}{G}, {T}, Sacrifice The World Tree: Search your library for any number of God cards, put them onto the battlefield, then shuffle.",Land,Land,,,False,,0.0,"B,G,R,U,W"
+17,"Shizo, Death's Storehouse","{T}: Add {B}.
+{B}, {T}: Target legendary creature gains fear until end of turn. (It can't be blocked except by artifact creatures and/or black creatures.)",Legendary Land,Land,,,False,,0.0,B
+18,Flooded Grove,"{T}: Add {C}.
+{G/U}, {T}: Add {G}{G}, {G}{U}, or {U}{U}.",Land,Land,,,False,,0.0,"G,U"
+19,Deathcap Glade,"Deathcap Glade enters the battlefield tapped unless you control two or more other lands.
+{T}: Add {B} or {G}.",Land,Land,,,False,,0.0,"B,G"
+20,Breeding Pool,"({T}: Add {G} or {U}.)
+As Breeding Pool enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",Land - Forest Island,Land,,,False,,0.0,"G,U"
+21,Sulfurous Springs,"{T}: Add {C}.
+{T}: Add {B} or {R}. Sulfurous Springs deals 1 damage to you.",Land,Land,,,False,,0.0,"B,R"
+22,Rockfall Vale,"Rockfall Vale enters the battlefield tapped unless you control two or more other lands.
+{T}: Add {R} or {G}.",Land,Land,,,False,,0.0,"G,R"
+23,Shivan Reef,"{T}: Add {C}.
+{T}: Add {U} or {R}. Shivan Reef deals 1 damage to you.",Land,Land,,,False,,0.0,"R,U"
+24,Rejuvenating Springs,"Rejuvenating Springs enters the battlefield tapped unless you have two or more opponents.
+{T}: Add {G} or {U}.",Land,Land,,,False,,0.0,"G,U"
+25,Raffine's Tower,"({T}: Add {W}, {U}, or {B}.)
+Raffine's Tower enters the battlefield tapped.
+Cycling {3} ({3}, Discard this card: Draw a card.)",Land - Plains Island Swamp,Land,,,False,,0.0,"B,U,W"
+26,Ketria Triome,"({T}: Add {G}, {U}, or {R}.)
+Ketria Triome enters the battlefield tapped.
+Cycling {3} ({3}, Discard this card: Draw a card.)",Land - Forest Island Mountain,Land,,,False,,0.0,"G,R,U"
+27,Command Tower,{T}: Add one mana of any color in your commander's color identity.,Land,Land,,,False,,0.0,C
+28,Ziatora's Proving Ground,"({T}: Add {B}, {R}, or {G}.)
+Ziatora's Proving Ground enters the battlefield tapped.
+Cycling {3} ({3}, Discard this card: Draw a card.)",Land - Swamp Mountain Forest,Land,,,False,,0.0,"B,G,R"
+29,Kessig Wolf Run,"{T}: Add {C}.
+{X}{R}{G}, {T}: Target creature gets +X/+0 and gains trample until end of turn.",Land,Land,,,False,,0.0,"G,R"
+30,Caves of Koilos,"{T}: Add {C}.
+{T}: Add {W} or {B}. Caves of Koilos deals 1 damage to you.",Land,Land,,,False,,0.0,"B,W"
+31,Bountiful Promenade,"Bountiful Promenade enters the battlefield tapped unless you have two or more opponents.
+{T}: Add {G} or {W}.",Land,Land,,,False,,0.0,"G,W"
+32,Branchloft Pathway // Boulderloft Pathway,{T}: Add {G}.,Land,Land,,,False,,0.0,"G,W"
+33,Temple of Silence,"Temple of Silence enters the battlefield tapped.
+When Temple of Silence enters the battlefield, scry 1.
+{T}: Add {W} or {B}.",Land,Land,,,False,,0.0,"B,W"
+34,Riverglide Pathway // Lavaglide Pathway,{T}: Add {U}.,Land,Land,,,False,,0.0,"R,U"
+35,Temple Garden,"({T}: Add {G} or {W}.)
+As Temple Garden enters the battlefield, you may pay 2 life. If you don't, it enters the battlefield tapped.",Land - Forest Plains,Land,,,False,,0.0,"G,W"
+36,Wooded Bastion,"{T}: Add {C}.
+{G/W}, {T}: Add {G}{G}, {G}{W}, or {W}{W}.",Land,Land,,,False,,0.0,"G,W"
+37,Xander's Lounge,"({T}: Add {U}, {B}, or {R}.)
+Xander's Lounge enters the battlefield tapped.
+Cycling {3} ({3}, Discard this card: Draw a card.)",Land - Island Swamp Mountain,Land,,,False,,0.0,"B,R,U"
+38,"Otawara, Soaring City","{T}: Add {U}.
+Channel - {3}{U}, Discard Otawara, Soaring City: Return target artifact, creature, enchantment, or planeswalker to its owner's hand. This ability costs {1} less to activate for each legendary creature you control.",Legendary Land,Land,,,False,,0.0,U
+39,Surrak and Goreclaw,"Trample
+Other creatures you control have trample.
+Whenever another nontoken creature enters the battlefield under your control, put a +1/+1 counter on it. It gains haste until end of turn.",Legendary Creature - Human Bear,Creature,6,5,False,{4}{G}{G},6.0,G
+40,Azorius Signet,"{1}, {T}: Add {W}{U}.",Artifact,Artifact,,,False,{2},2.0,"U,W"
+41,Primevals' Glorious Rebirth,"(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)
+Return all legendary permanent cards from your graveyard to the battlefield.",Legendary Sorcery,Sorcery,,,False,{5}{W}{B},7.0,"B,W"
+42,Vedalken Orrery,You may cast spells as though they had flash.,Artifact,Artifact,,,False,{4},4.0,C
+43,"Nekusar, the Mindrazer","At the beginning of each player's draw step, that player draws an additional card.
+Whenever an opponent draws a card, Nekusar, the Mindrazer deals 1 damage to that player.",Legendary Creature - Zombie Wizard,Creature,2,4,False,{2}{U}{B}{R},5.0,"B,R,U"
+44,Merciless Eviction,"Choose one -
+• Exile all artifacts.
+• Exile all creatures.
+• Exile all enchantments.
+• Exile all planeswalkers.",Sorcery,Sorcery,,,False,{4}{W}{B},6.0,"B,W"
+45,"Atla Palani, Nest Tender","{2}, {T}: Create a 0/1 green Egg creature token with defender.
+Whenever an Egg you control dies, reveal cards from the top of your library until you reveal a creature card. Put that card onto the battlefield and the rest on the bottom of your library in a random order.",Legendary Creature - Human Shaman,Creature,2,3,False,{1}{R}{G}{W},4.0,"G,R,W"
+46,Ertai Resurrected,"Flash
+When Ertai Resurrected enters the battlefield, choose up to one -
+• Counter target spell, activated ability, or triggered ability. Its controller draws a card.
+• Destroy another target creature or planeswalker. Its controller draws a card.",Legendary Creature - Phyrexian Human Wizard,Creature,3,2,False,{2}{U}{B},4.0,"B,U"
+47,"Omnath, Locus of All","If you would lose unspent mana, that mana becomes black instead.
+At the beginning of your precombat main phase, look at the top card of your library. You may reveal that card if it has three or more colored mana symbols in its mana cost. If you do, add three mana in any combination of its colors and put it into your hand. If you don't reveal it, put it into your hand.",Legendary Creature - Phyrexian Elemental,Creature,4,4,False,{W}{U}{B/P}{R}{G},5.0,"B,G,R,U,W"
+48,"Elspeth, Sun's Champion","[+1]: Create three 1/1 white Soldier creature tokens.
+[−3]: Destroy all creatures with power 4 or greater.
+[−7]: You get an emblem with ""Creatures you control get +2/+2 and have flying.""",Legendary Planeswalker - Elspeth,Planeswalker,,,False,{4}{W}{W},6.0,W
+49,Relic of Legends,"{T}: Add one mana of any color.
+Tap an untapped legendary creature you control: Add one mana of any color.",Artifact,Artifact,,,False,{3},3.0,C
+50,Chromatic Orrery,"You may spend mana as though it were mana of any color.
+{T}: Add {C}{C}{C}{C}{C}.
+{5}, {T}: Draw a card for each color among permanents you control.",Legendary Artifact,Artifact,,,False,{7},7.0,C
+51,Mox Amber,{T}: Add one mana of any color among legendary creatures and planeswalkers you control.,Legendary Artifact,Artifact,,,False,{0},0.0,C
+52,Teferi's Protection,"Until your next turn, your life total can't change and you gain protection from everything. All permanents you control phase out. (While they're phased out, they're treated as though they don't exist. They phase in before you untap during your untap step.)
+Exile Teferi's Protection.",Instant,Instant,,,False,{2}{W},3.0,W
+53,Jace Beleren,"[+2]: Each player draws a card.
+[−1]: Target player draws a card.
+[−10]: Target player mills twenty cards.",Legendary Planeswalker - Jace,Planeswalker,,,False,{1}{U}{U},3.0,U
+54,Reinterpret,Counter target spell. You may cast a spell with an equal or lesser mana value from your hand without paying its mana cost.,Instant,Instant,,,False,{2}{U}{R},4.0,"R,U"
+55,"Atsushi, the Blazing Sky","Flying, trample
+When Atsushi, the Blazing Sky dies, choose one -
+• Exile the top two cards of your library. Until the end of your next turn, you may play those cards.
+• Create three Treasure tokens.",Legendary Creature - Dragon Spirit,Creature,4,4,False,{2}{R}{R},4.0,R
+56,"Jodah, Archmage Eternal","Flying
+You may pay {W}{U}{B}{R}{G} rather than pay the mana cost for spells that you cast.",Legendary Creature - Human Wizard,Creature,4,3,False,{1}{U}{R}{W},4.0,"B,G,R,U,W"
+57,Kodama of the East Tree,"Reach
+Whenever another permanent enters the battlefield under your control, if it wasn't put onto the battlefield with this ability, you may put a permanent card with equal or lesser mana value from your hand onto the battlefield.
+Partner (You can have two commanders if both have partner.)",Legendary Creature - Spirit,Creature,6,6,False,{4}{G}{G},6.0,G
+58,"Teferi, Mage of Zhalfir","Flash
+Creature cards you own that aren't on the battlefield have flash.
+Each opponent can cast spells only any time they could cast a sorcery.",Legendary Creature - Human Wizard,Creature,3,4,False,{2}{U}{U}{U},5.0,U
+59,Heroic Intervention,Permanents you control gain hexproof and indestructible until end of turn.,Instant,Instant,,,False,{1}{G},2.0,G
+60,"Teferi, Temporal Archmage","[+1]: Look at the top two cards of your library. Put one of them into your hand and the other on the bottom of your library.
+[−1]: Untap up to four target permanents.
+[−10]: You get an emblem with ""You may activate loyalty abilities of planeswalkers you control on any player's turn any time you could cast an instant.""
+Teferi, Temporal Archmage can be your commander.",Legendary Planeswalker - Teferi,Planeswalker,,,False,{4}{U}{U},6.0,U
+61,"Sisay, Weatherlight Captain","Sisay, Weatherlight Captain gets +1/+1 for each color among other legendary permanents you control.
+{W}{U}{B}{R}{G}: Search your library for a legendary permanent card with mana value less than Sisay's power, put that card onto the battlefield, then shuffle.",Legendary Creature - Human Soldier,Creature,2,2,False,{2}{W},3.0,"B,G,R,U,W"
+62,Maelstrom Nexus,"The first spell you cast each turn has cascade. (When you cast your first spell, exile cards from the top of your library until you exile a nonland card that costs less. You may cast it without paying its mana cost. Put the exiled cards on the bottom of your library in a random order.)",Enchantment,Enchantment,,,False,{W}{U}{B}{R}{G},5.0,"B,G,R,U,W"
+63,Talisman of Curiosity,"{T}: Add {C}.
+{T}: Add {G} or {U}. Talisman of Curiosity deals 1 damage to you.",Artifact,Artifact,,,False,{2},2.0,"G,U"
+64,"Akroma, Vision of Ixidor","Flying, first strike, vigilance, trample
+At the beginning of each combat, until end of turn, each other creature you control gets +1/+1 if it has flying, +1/+1 if it has first strike, and so on for double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, vigilance, and partner.
+Partner",Legendary Creature - Angel,Creature,6,6,False,{5}{W}{W},7.0,W
+65,Genesis Ultimatum,Look at the top five cards of your library. Put any number of permanent cards from among them onto the battlefield and the rest into your hand. Exile Genesis Ultimatum.,Sorcery,Sorcery,,,False,{G}{G}{U}{U}{U}{R}{R},7.0,"G,R,U"
+66,"Koma, Cosmos Serpent","This spell can't be countered.
+At the beginning of each upkeep, create a 3/3 blue Serpent creature token named Koma's Coil.
+Sacrifice another Serpent: Choose one -
+• Tap target permanent. Its activated abilities can't be activated this turn.
+• Koma, Cosmos Serpent gains indestructible until end of turn.",Legendary Creature - Serpent,Creature,6,6,False,{3}{G}{G}{U}{U},7.0,"G,U"
+67,Smothering Tithe,"Whenever an opponent draws a card, that player may pay {2}. If the player doesn't, you create a Treasure token. (It's an artifact with ""{T}, Sacrifice this artifact: Add one mana of any color."")",Enchantment,Enchantment,,,False,{3}{W},4.0,W
+68,"Shanid, Sleepers' Scourge","Menace
+Other legendary creatures you control have menace.
+Whenever you play a legendary land or cast a legendary spell, you draw a card and you lose 1 life.",Legendary Creature - Human Knight,Creature,2,4,False,{1}{R}{W}{B},4.0,"B,R,W"
+69,"Kenrith, the Returned King","{R}: All creatures gain trample and haste until end of turn.
+{1}{G}: Put a +1/+1 counter on target creature.
+{2}{W}: Target player gains 5 life.
+{3}{U}: Target player draws a card.
+{4}{B}: Put target creature card from a graveyard onto the battlefield under its owner's control.",Legendary Creature - Human Noble,Creature,5,5,False,{4}{W},5.0,"B,G,R,U,W"
+70,God-Eternal Rhonas,"Deathtouch
+When God-Eternal Rhonas enters the battlefield, double the power of each other creature you control until end of turn. Those creatures gain vigilance until end of turn.
+When God-Eternal Rhonas dies or is put into exile from the battlefield, you may put it into its owner's library third from the top.",Legendary Creature - Zombie God,Creature,5,5,False,{3}{G}{G},5.0,G
+71,Sol Ring,{T}: Add {C}{C}.,Artifact,Artifact,,,False,{1},1.0,C
+72,Duneblast,Choose up to one creature. Destroy the rest.,Sorcery,Sorcery,,,False,{4}{W}{B}{G},7.0,"B,G,W"
+73,"Venser, Shaper Savant","Flash
+When Venser, Shaper Savant enters the battlefield, return target spell or permanent to its owner's hand.",Legendary Creature - Human Wizard,Creature,2,2,False,{2}{U}{U},4.0,U
+74,"Illuna, Apex of Wishes","Mutate {3}{R/G}{U}{U} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)
+Flying, trample
+Whenever this creature mutates, exile cards from the top of your library until you exile a nonland permanent card. Put that card onto the battlefield or into your hand.",Legendary Creature - Beast Elemental Dinosaur,Creature,6,6,False,{2}{G}{U}{R},5.0,"G,R,U"
+75,"Venser, the Sojourner","[+2]: Exile target permanent you own. Return it to the battlefield under your control at the beginning of the next end step.
+[−1]: Creatures can't be blocked this turn.
+[−8]: You get an emblem with ""Whenever you cast a spell, exile target permanent.""",Legendary Planeswalker - Venser,Planeswalker,,,False,{3}{W}{U},5.0,"U,W"
+76,Urza's Ruinous Blast,"(You may cast a legendary sorcery only if you control a legendary creature or planeswalker.)
+Exile all nonland permanents that aren't legendary.",Legendary Sorcery,Sorcery,,,False,{4}{W},5.0,W
+77,Obsidian Obelisk,"Obsidian Obelisk enters the battlefield tapped.
+{T}: Add {C}.
+{T}: Add one mana of any color. Spend this mana only to cast a multicolored spell.",Artifact,Artifact,,,False,{2},2.0,C
+78,Asceticism,"Creatures you control have hexproof. (They can't be the targets of spells or abilities your opponents control.)
+{1}{G}: Regenerate target creature.",Enchantment,Enchantment,,,False,{3}{G}{G},5.0,G
+79,Genesis Wave,Reveal the top X cards of your library. You may put any number of permanent cards with mana value X or less from among them onto the battlefield. Then put all cards revealed this way that weren't put onto the battlefield into your graveyard.,Sorcery,Sorcery,,,False,{X}{G}{G}{G},3.0,G
+80,"Sorin, Grim Nemesis","[+1]: Reveal the top card of your library and put that card into your hand. Each opponent loses life equal to its mana value.
+[−X]: Sorin, Grim Nemesis deals X damage to target creature or planeswalker and you gain X life.
+[−9]: Create a number of 1/1 black Vampire Knight creature tokens with lifelink equal to the highest life total among all players.",Legendary Planeswalker - Sorin,Planeswalker,,,False,{4}{W}{B},6.0,"B,W"
+81,Surrak Dragonclaw,"Flash
+This spell can't be countered.
+Creature spells you control can't be countered.
+Other creatures you control have trample.",Legendary Creature - Human Warrior,Creature,6,6,False,{2}{G}{U}{R},5.0,"G,R,U"
+82,"Nylea, Keen-Eyed","Indestructible
+As long as your devotion to green is less than five, Nylea isn't a creature.
+Creature spells you cast cost {1} less to cast.
+{2}{G}: Reveal the top card of your library. If it's a creature card, put it into your hand. Otherwise, you may put it into your graveyard.",Legendary Enchantment Creature - God,"Enchantment,Creature",5,6,False,{3}{G},4.0,G
+83,Sakashima the Impostor,"You may have Sakashima the Impostor enter the battlefield as a copy of any creature on the battlefield, except its name is Sakashima the Impostor, it's legendary in addition to its other types, and it has ""{2}{U}{U}: Return this creature to its owner's hand at the beginning of the next end step.""",Legendary Creature - Human Rogue,Creature,3,1,False,{2}{U}{U},4.0,U
+84,Blackblade Reforged,"Equipped creature gets +1/+1 for each land you control.
+Equip legendary creature {3}
+Equip {7}",Legendary Artifact - Equipment,Artifact,,,False,{2},2.0,C
+85,"Isperia, Supreme Judge","Flying
+Whenever a creature attacks you or a planeswalker you control, you may draw a card.",Legendary Creature - Sphinx,Creature,6,4,False,{2}{W}{W}{U}{U},6.0,"U,W"
+86,"Nethroi, Apex of Death","Mutate {4}{G/W}{B}{B} (If you cast this spell for its mutate cost, put it over or under target non-Human creature you own. They mutate into the creature on top plus all abilities from under it.)
+Deathtouch, lifelink
+Whenever this creature mutates, return any number of target creature cards with total power 10 or less from your graveyard to the battlefield.",Legendary Creature - Cat Nightmare Beast,Creature,5,5,False,{2}{W}{B}{G},5.0,"B,G,W"
+87,Arcane Signet,{T}: Add one mana of any color in your commander's color identity.,Artifact,Artifact,,,False,{2},2.0,C
+88,Akroma's Memorial,"Creatures you control have flying, first strike, vigilance, trample, haste, and protection from black and from red.",Legendary Artifact,Artifact,,,False,{7},7.0,C
+89,"Ryusei, the Falling Star","Flying
+When Ryusei, the Falling Star dies, it deals 5 damage to each creature without flying.",Legendary Creature - Dragon Spirit,Creature,5,5,False,{5}{R},6.0,R
+90,Fellwar Stone,{T}: Add one mana of any color that a land an opponent controls could produce.,Artifact,Artifact,,,False,{2},2.0,C
+91,"Sigarda, Host of Herons","Flying, hexproof
+Spells and abilities your opponents control can't cause you to sacrifice permanents.",Legendary Creature - Angel,Creature,5,5,False,{2}{G}{W}{W},5.0,"G,W"
+92,"Garruk, Caller of Beasts","[+1]: Reveal the top five cards of your library. Put all creature cards revealed this way into your hand and the rest on the bottom of your library in any order.
+[−3]: You may put a green creature card from your hand onto the battlefield.
+[−7]: You get an emblem with ""Whenever you cast a creature spell, you may search your library for a creature card, put it onto the battlefield, then shuffle.""",Legendary Planeswalker - Garruk,Planeswalker,,,False,{4}{G}{G},6.0,G
+93,"Zacama, Primal Calamity","Vigilance, reach, trample
+When Zacama, Primal Calamity enters the battlefield, if you cast it, untap all lands you control.
+{2}{R}: Zacama deals 3 damage to target creature.
+{2}{G}: Destroy target artifact or enchantment.
+{2}{W}: You gain 3 life.",Legendary Creature - Elder Dinosaur,Creature,9,9,False,{6}{R}{G}{W},9.0,"G,R,W"
+94,"Avacyn, Angel of Hope","Flying, vigilance, indestructible
+Other permanents you control have indestructible.",Legendary Creature - Angel,Creature,8,8,False,{5}{W}{W}{W},8.0,W
+95,"Nicol Bolas, Planeswalker","[+3]: Destroy target noncreature permanent.
+[−2]: Gain control of target creature.
+[−9]: Nicol Bolas, Planeswalker deals 7 damage to target player or planeswalker. That player or that planeswalker's controller discards seven cards, then sacrifices seven permanents.",Legendary Planeswalker - Bolas,Planeswalker,,,False,{4}{U}{B}{B}{R},8.0,"B,R,U"
+96,"Dihada, Binder of Wills","[+2]: Up to one target legendary creature gains vigilance, lifelink, and indestructible until your next turn.
+[−3]: Reveal the top four cards of your library. Put any number of legendary cards from among them into your hand and the rest into your graveyard. Create a Treasure token for each card put into your graveyard this way.
+[−11]: Gain control of all nonland permanents until end of turn. Untap them. They gain haste until end of turn.
+Dihada, Binder of Wills can be your commander.",Legendary Planeswalker - Dihada,Planeswalker,,,False,{1}{R}{W}{B},4.0,"B,R,W"
+97,"Zagras, Thief of Heartbeats","This spell costs {1} less to cast for each creature in your party.
+Flying, deathtouch, haste
+Other creatures you control have deathtouch.
+Whenever a creature you control deals combat damage to a planeswalker, destroy that planeswalker.",Legendary Creature - Vampire Rogue,Creature,4,4,False,{4}{B}{R},6.0,"B,R"
+98,"Rashmi, Eternities Crafter","Whenever you cast your first spell each turn, reveal the top card of your library. You may cast it without paying its mana cost if it's a spell with lesser mana value. If you don't cast it, put it into your hand.",Legendary Creature - Elf Druid,Creature,2,3,False,{2}{G}{U},4.0,"G,U"
+99,"Realmbreaker, the Invasion Tree","{2}, {T}: Target opponent mills three cards. Put a land card from their graveyard onto the battlefield tapped under your control. It gains ""If this land would leave the battlefield, exile it instead of putting it anywhere else.""
+{10}, {T}, Sacrifice Realmbreaker, the Invasion Tree: Search your library for any number of Praetor cards, put them onto the battlefield, then shuffle.",Legendary Artifact,Artifact,,,False,{3},3.0,C


### PR DESCRIPTION
-added a function to load a pre-existing deck(csv file), more load options coming soon.
-added a function to count the number of times a mana symbol appears in cards in the deck. Currently only on loaded decks not newly created ones. Will add the functionality to newly created decks soon.

The functions above are still works in progress, more updates soon.